### PR TITLE
Fix: failure when using unicode characters

### DIFF
--- a/jukebox/save_html.py
+++ b/jukebox/save_html.py
@@ -4,14 +4,15 @@ import numpy as np
 from PIL import Image, ImageFilter
 import soundfile
 
+
 def save_html(logdir, x, zs, labels, alignments, hps):
-    level = hps.levels - 1 # Top level used
+    level = hps.levels - 1  # Top level used
     z = zs[level]
     bs, total_length = z.shape[0], z.shape[1]
 
-    with open(f'{logdir}/index.html', 'w') as html:
+    with open(f'{logdir}/index.html', 'w', encoding='utf-8') as html:
         print(f"<html><head><title>{logdir}</title></head><body style='font-family: sans-serif; font-size: 1.4em; font-weight: bold; text-align: center; max-width:1024px; width: 100%; margin: auto;'>",
-            file=html)
+              file=html)
         print("<link rel='icon' href='data:;base64,iVBORw0KGgo='>", file=html)
 
         for item in range(bs):
@@ -22,8 +23,10 @@ def save_html(logdir, x, zs, labels, alignments, hps):
                         alignment=alignments[item] if alignments is not None else None)
             item_dir = f'{logdir}/item_{item}'
             _save_item_html(item_dir, item, item, data)
-            print(f"<iframe style='height: 100%; width: 100%;' frameborder='0' scrolling='no' src='item_{item}/index.html'></iframe>", file=html)
-        print("</body></html>", file=html)  
+            print(
+                f"<iframe style='height: 100%; width: 100%;' frameborder='0' scrolling='no' src='item_{item}/index.html'></iframe>", file=html)
+        print("</body></html>", file=html)
+
 
 def _save_item_html(item_dir, item_id, item_name, data):
     # replace gs:// with /root/samples/
@@ -32,9 +35,9 @@ def _save_item_html(item_dir, item_id, item_name, data):
     if not os.path.exists(item_dir):
         os.makedirs(item_dir)
 
-    with open(f'{item_dir}/index.html', 'w') as html:
+    with open(f'{item_dir}/index.html', 'w', encoding="utf-8") as html:
         print(f"<html><head><title>{item_name}</title></head><body style='font-family: sans-serif; font-size: 1.4em; font-weight: bold; text-align: center; max-width:1024px; width: 100%; margin: auto;'>",
-            file=html)
+              file=html)
         print("<link rel='icon' href='data:;base64,iVBORw0KGgo='>", file=html)
         total_length = data['total_length']
         total_tokens = data['total_tokens']
@@ -46,36 +49,40 @@ def _save_item_html(item_dir, item_id, item_name, data):
         # Strip unused columns
         if alignment is not None:
             assert alignment.shape == (total_length, total_tokens)
-            assert len(lyrics) == total_tokens, f'Total_tokens: {total_tokens}, Lyrics Len: {len(lyrics)}. Lyrics: {lyrics}'
+            assert len(
+                lyrics) == total_tokens, f'Total_tokens: {total_tokens}, Lyrics Len: {len(lyrics)}. Lyrics: {lyrics}'
             max_attn_at_token = np.max(alignment, axis=0)
             assert len(max_attn_at_token) == total_tokens
             for token in reversed(range(total_tokens)):
                 if max_attn_at_token[token] > 0:
                     break
-            alignment = alignment[:,:token+1]
+            alignment = alignment[:, :token+1]
             lyrics = lyrics[:token+1]
             total_tokens = token+1
 
             # Small alignment image
-            im = Image.fromarray(np.uint8(alignment * 255)).resize((512, 1024)).transpose(Image.ROTATE_90)
+            im = Image.fromarray(np.uint8(alignment * 255)
+                                 ).resize((512, 1024)).transpose(Image.ROTATE_90)
             img_src = f'align.png'
             im.save(f'{item_dir}/{img_src}')
             print(f"<img id='{img_src}' src='{img_src}' \>", file=html)
 
             # Smaller alignment json for animation
             total_alignment_length = total_length // 16
-            alignment = Image.fromarray(np.uint8(alignment * 255)).resize((total_tokens, total_alignment_length))
+            alignment = Image.fromarray(
+                np.uint8(alignment * 255)).resize((total_tokens, total_alignment_length))
             alignment = alignment.filter(ImageFilter.GaussianBlur(radius=1.5))
             alignment = np.asarray(alignment).tolist()
             align_src = f'align.json'
-            with open(f'{item_dir}/{align_src}', 'w') as f:
+            with open(f'{item_dir}/{align_src}', 'w', encoding="utf-8") as f:
                 json.dump(alignment, f)
 
         # Audio
         wav_src = f'audio.wav'
-        soundfile.write(f'{item_dir}/{wav_src}', wav, samplerate=sr, format='wav')
-        print(f"<audio id='{wav_src}' src='{wav_src}' style='width: 100%;' controls></audio>", file=html)
-
+        soundfile.write(f'{item_dir}/{wav_src}', wav,
+                        samplerate=sr, format='wav')
+        print(
+            f"<audio id='{wav_src}' src='{wav_src}' style='width: 100%;' controls></audio>", file=html)
 
         # Labels and Lyrics
         print(f"<pre style='white-space: pre-wrap;'>", end="", file=html)
@@ -85,7 +92,7 @@ def _save_item_html(item_dir, item_id, item_name, data):
         for i, c in enumerate(lyrics):
             print(f"<span id='{item_id}/{i}'>{c}</span>", end="", file=html)
         print(f"</pre>", file=html)
-        with open(f'{item_dir}/lyrics.json', 'w') as f:
+        with open(f'{item_dir}/lyrics.json', 'w', encoding="utf-8") as f:
             json.dump(lyrics, f)
 
         if alignment is not None:

--- a/jukebox/save_html.py
+++ b/jukebox/save_html.py
@@ -10,21 +10,28 @@ def save_html(logdir, x, zs, labels, alignments, hps):
     z = zs[level]
     bs, total_length = z.shape[0], z.shape[1]
 
-    with open(f'{logdir}/index.html', 'w', encoding='utf-8') as html:
-        print(f"<html><head><title>{logdir}</title></head><body style='font-family: sans-serif; font-size: 1.4em; font-weight: bold; text-align: center; max-width:1024px; width: 100%; margin: auto;'>",
-              file=html)
+    with open(f"{logdir}/index.html", "w", encoding="utf-8") as html:
+        print(
+            f"<html><head><title>{logdir}</title></head><body style='font-family: sans-serif; font-size: 1.4em; font-weight: bold; text-align: center; max-width:1024px; width: 100%; margin: auto;'>",
+            file=html,
+        )
         print("<link rel='icon' href='data:;base64,iVBORw0KGgo='>", file=html)
 
         for item in range(bs):
-            data = dict(wav=x[item].cpu().numpy(), sr=hps.sr,
-                        info=labels['info'][item],
-                        total_length=total_length,
-                        total_tokens=len(labels['info'][item]['full_tokens']),
-                        alignment=alignments[item] if alignments is not None else None)
-            item_dir = f'{logdir}/item_{item}'
+            data = dict(
+                wav=x[item].cpu().numpy(),
+                sr=hps.sr,
+                info=labels["info"][item],
+                total_length=total_length,
+                total_tokens=len(labels["info"][item]["full_tokens"]),
+                alignment=alignments[item] if alignments is not None else None,
+            )
+            item_dir = f"{logdir}/item_{item}"
             _save_item_html(item_dir, item, item, data)
             print(
-                f"<iframe style='height: 100%; width: 100%;' frameborder='0' scrolling='no' src='item_{item}/index.html'></iframe>", file=html)
+                f"<iframe style='height: 100%; width: 100%;' frameborder='0' scrolling='no' src='item_{item}/index.html'></iframe>",
+                file=html,
+            )
         print("</body></html>", file=html)
 
 
@@ -35,87 +42,106 @@ def _save_item_html(item_dir, item_id, item_name, data):
     if not os.path.exists(item_dir):
         os.makedirs(item_dir)
 
-    with open(f'{item_dir}/index.html', 'w', encoding="utf-8") as html:
-        print(f"<html><head><title>{item_name}</title></head><body style='font-family: sans-serif; font-size: 1.4em; font-weight: bold; text-align: center; max-width:1024px; width: 100%; margin: auto;'>",
-              file=html)
+    with open(f"{item_dir}/index.html", "w", encoding="utf-8") as html:
+        print(
+            f"<html><head><title>{item_name}</title></head><body style='font-family: sans-serif; font-size: 1.4em; font-weight: bold; text-align: center; max-width:1024px; width: 100%; margin: auto;'>",
+            file=html,
+        )
         print("<link rel='icon' href='data:;base64,iVBORw0KGgo='>", file=html)
-        total_length = data['total_length']
-        total_tokens = data['total_tokens']
-        alignment = data['alignment']
+        total_length = data["total_length"]
+        total_tokens = data["total_tokens"]
+        alignment = data["alignment"]
         lyrics = data["info"]["lyrics"]
-        wav, sr = data['wav'], data['sr']
+        wav, sr = data["wav"], data["sr"]
         genre, artist = data["info"]["genre"], data["info"]["artist"]
 
         # Strip unused columns
         if alignment is not None:
             assert alignment.shape == (total_length, total_tokens)
-            assert len(
-                lyrics) == total_tokens, f'Total_tokens: {total_tokens}, Lyrics Len: {len(lyrics)}. Lyrics: {lyrics}'
+            assert (
+                len(lyrics) == total_tokens
+            ), f"Total_tokens: {total_tokens}, Lyrics Len: {len(lyrics)}. Lyrics: {lyrics}"
             max_attn_at_token = np.max(alignment, axis=0)
             assert len(max_attn_at_token) == total_tokens
             for token in reversed(range(total_tokens)):
                 if max_attn_at_token[token] > 0:
                     break
-            alignment = alignment[:, :token+1]
-            lyrics = lyrics[:token+1]
-            total_tokens = token+1
+            alignment = alignment[:, : token + 1]
+            lyrics = lyrics[: token + 1]
+            total_tokens = token + 1
 
             # Small alignment image
-            im = Image.fromarray(np.uint8(alignment * 255)
-                                 ).resize((512, 1024)).transpose(Image.ROTATE_90)
-            img_src = f'align.png'
-            im.save(f'{item_dir}/{img_src}')
+            im = (
+                Image.fromarray(np.uint8(alignment * 255))
+                .resize((512, 1024))
+                .transpose(Image.ROTATE_90)
+            )
+            img_src = f"align.png"
+            im.save(f"{item_dir}/{img_src}")
             print(f"<img id='{img_src}' src='{img_src}' \>", file=html)
 
             # Smaller alignment json for animation
             total_alignment_length = total_length // 16
-            alignment = Image.fromarray(
-                np.uint8(alignment * 255)).resize((total_tokens, total_alignment_length))
+            alignment = Image.fromarray(np.uint8(alignment * 255)).resize(
+                (total_tokens, total_alignment_length)
+            )
             alignment = alignment.filter(ImageFilter.GaussianBlur(radius=1.5))
             alignment = np.asarray(alignment).tolist()
-            align_src = f'align.json'
-            with open(f'{item_dir}/{align_src}', 'w', encoding="utf-8") as f:
+            align_src = f"align.json"
+            with open(f"{item_dir}/{align_src}", "w", encoding="utf-8") as f:
                 json.dump(alignment, f)
 
         # Audio
-        wav_src = f'audio.wav'
-        soundfile.write(f'{item_dir}/{wav_src}', wav,
-                        samplerate=sr, format='wav')
+        wav_src = f"audio.wav"
+        soundfile.write(f"{item_dir}/{wav_src}", wav, samplerate=sr, format="wav")
         print(
-            f"<audio id='{wav_src}' src='{wav_src}' style='width: 100%;' controls></audio>", file=html)
+            f"<audio id='{wav_src}' src='{wav_src}' style='width: 100%;' controls></audio>",
+            file=html,
+        )
 
         # Labels and Lyrics
         print(f"<pre style='white-space: pre-wrap;'>", end="", file=html)
         print(f"<div>Artist {artist}, Genre {genre}</div>", file=html)
         lyrics = [c for c in lyrics]  # already characters actually
-        lyrics = [''] + lyrics[:-1]  # input lyrics are shifted by 1
+        lyrics = [""] + lyrics[:-1]  # input lyrics are shifted by 1
         for i, c in enumerate(lyrics):
             print(f"<span id='{item_id}/{i}'>{c}</span>", end="", file=html)
         print(f"</pre>", file=html)
-        with open(f'{item_dir}/lyrics.json', 'w', encoding="utf-8") as f:
+        with open(f"{item_dir}/lyrics.json", "w", encoding="utf-8") as f:
             json.dump(lyrics, f)
 
         if alignment is not None:
             # JS for alignment animation
-            print("""<script>
+            print(
+                """<script>
             async function fetchAsync (url) {
                 let response = await fetch(url);
                 let data = await response.json();
                 return data;
             }
     
-            var audio = document.getElementById('""" + f'{wav_src}' + """');
+            var audio = document.getElementById('"""
+                + f"{wav_src}"
+                + """');
             audio.onplay = function () {
-                track = '""" + f'{item_id}' + """'
-                fetchAsync('""" + f'{align_src}' + """')
+                track = '"""
+                + f"{item_id}"
+                + """'
+                fetchAsync('"""
+                + f"{align_src}"
+                + """')
                 .then(data => animateLyrics(data, track, this))
                 .catch(reason => console.log(reason.message))
             }; 
     
             function animateLyrics(data, track, audio) {
                 var animate = setInterval(function () {
-                    var time = Math.floor(audio.currentTime*""" + f'{total_alignment_length}' + """/audio.duration);
-                    if (!(time == 0 || time == """ + f'{total_alignment_length}' + """)) {
+                    var time = Math.floor(audio.currentTime*"""
+                + f"{total_alignment_length}"
+                + """/audio.duration);
+                    if (!(time == 0 || time == """
+                + f"{total_alignment_length}"
+                + """)) {
                         console.log(time);
                         changeColor(data, track, audio, time);
                     }
@@ -133,5 +159,7 @@ def _save_item_html(item_dir, item_id, item_name, data):
                     character.style.color = 'rgb(255,' + color + ',' + color + ')';
                 }
             }
-            </script>""", file=html)
+            </script>""",
+                file=html,
+            )
         print("</body></html>", file=html)


### PR DESCRIPTION
To reproduce:
Create an ancestral track using the "rock en español" genre from 1b.  

Expected Result:
Render completes and encodes "ñ" character when writing html

Actual Result:
Render halts after level_2 rendering due to an ascii encoding error while writing HTML, ("ñ" character is outside of ascii range).

Fix:
This sets all HTML and JSON encodings to utf-8 when opening them for writing.

This file has also been formatted with black https://github.com/psf/black